### PR TITLE
Added Geo Lock middleware restricting DolFin to Australia

### DIFF
--- a/neo_dolfin/app.py
+++ b/neo_dolfin/app.py
@@ -1,4 +1,4 @@
-from flask import Flask, render_template, redirect, url_for, request, session, jsonify
+from flask import Flask, Response, render_template, redirect, url_for, request, session, jsonify
 from flask_wtf import FlaskForm
 from wtforms import StringField, PasswordField, SubmitField
 from wtforms.validators import DataRequired, EqualTo, Email, Regexp
@@ -111,6 +111,36 @@ else:
 
 ## Basiq API 
 basiq_service = BasiqService()
+
+# GEO LOCK MIDDLEWARE - Restricts to Australia or Localhost IPs
+class GeoLockChecker(object):
+    def __init__(self, app):
+        self.app = app
+
+    def __call__(self, environ, start_response):
+        ip_addr = environ.get('REMOTE_ADDR', '')
+        if self.is_australia_or_localhost(ip_addr):
+            # Proceed normally if user in AU or Localhost
+            return self.app(environ, start_response)
+        else:
+            response = Response('Sorry, you are restricted from accessing this content. It is only available in Australia.', mimetype='text/html')
+            return response(environ, start_response)
+        
+    def is_australia_or_localhost(self, ip_addr):
+        if ip_addr == "127.0.0.1":
+            return 1
+        response = requests.get('http://ip-api.com/json/' + ip_addr)
+        if response.status_code == 200:
+            geo_info = response.json()
+            if(geo_info["country"] == "Australia"):
+                return 1
+            else:
+                return 0
+        else:
+            return 0
+
+
+app.wsgi_app = GeoLockChecker(app.wsgi_app)
 
 # ROUTING
 

--- a/neo_dolfin/app.py
+++ b/neo_dolfin/app.py
@@ -123,7 +123,7 @@ class GeoLockChecker(object):
             # Proceed normally if user in AU or Localhost
             return self.app(environ, start_response)
         else:
-            response = Response('Sorry, you are restricted from accessing this content. It is only available in Australia.', mimetype='text/html')
+            response = Response('Sorry, you are restricted from accessing this content. It is only available in Australia.', mimetype='text/html', status=403)
             return response(environ, start_response)
         
     def is_australia_or_localhost(self, ip_addr):

--- a/neo_dolfin/test/test_app.py
+++ b/neo_dolfin/test/test_app.py
@@ -6,3 +6,22 @@ def test_app_runs():
     response = client.get('/')
     assert response.status_code == 200
     assert "DolFin | Landing" in response.data.decode('utf-8')
+
+def test_app_geolock():
+    client = app.test_client()
+    usa_header = {'REMOTE_ADDR': '185.169.0.168'}       # American IP
+    aus_header = {'REMOTE_ADDR': '103.192.80.189'}      # Australian IP
+    france_header = {'REMOTE_ADDR': '45.141.123.17'}    # French IP
+    localhost_header = {'REMOTE_ADDR': '127.0.0.1'}     # Localhost IP
+    response = client.get('/', environ_overrides=usa_header)
+    assert response.status_code == 403
+    assert "Sorry, you are restricted from accessing this content." in response.data.decode('utf-8')
+    response = client.get('/', environ_overrides=france_header)
+    assert response.status_code == 403
+    assert "Sorry, you are restricted from accessing this content." in response.data.decode('utf-8')
+    response = client.get('/', environ_overrides=aus_header)
+    assert response.status_code == 200
+    assert "DolFin | Landing" in response.data.decode('utf-8')
+    response = client.get('/', environ_overrides=localhost_header)
+    assert response.status_code == 200
+    assert "DolFin | Landing" in response.data.decode('utf-8')


### PR DESCRIPTION
(Cyber Security) I used wsgi_app to create a GeoLockChecker middleware. It checks for user's IP against IP-API to retrieve the country info. The user is only allowed to access all of the pages if they're located in Australia or accessing from localhost (for dev purposes).